### PR TITLE
Rebrand from nVotes to Sequent Tech

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 name: ORT licensing

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.ort-data/curations-dir/bsd_license.yml
+++ b/.ort-data/curations-dir/bsd_license.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 ---

--- a/.ort-data/curations-dir/distlib.yml
+++ b/.ort-data/curations-dir/distlib.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::distlib"

--- a/.ort-data/curations-dir/drangandroptouch.yml
+++ b/.ort-data/curations-dir/drangandroptouch.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "dragandroptouch"

--- a/.ort-data/curations-dir/fractionjs.yml
+++ b/.ort-data/curations-dir/fractionjs.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "NPM::fraction.js"

--- a/.ort-data/curations-dir/java.yml
+++ b/.ort-data/curations-dir/java.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "Maven:javax.cache:cache-api"

--- a/.ort-data/curations-dir/jszip.yml
+++ b/.ort-data/curations-dir/jszip.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "NPM::jszip"

--- a/.ort-data/curations-dir/psycopg2-binary.yml
+++ b/.ort-data/curations-dir/psycopg2-binary.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::psycopg2-binary"

--- a/.ort-data/curations-dir/pycryptodomex.yml
+++ b/.ort-data/curations-dir/pycryptodomex.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::pycryptodomex"

--- a/.ort-data/curations-dir/reportlab.yml
+++ b/.ort-data/curations-dir/reportlab.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::reportlab"

--- a/.ort-data/curations-dir/rng-js.yml
+++ b/.ort-data/curations-dir/rng-js.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "NPM::rng-js"

--- a/.ort-data/curations-dir/voting-booth.yml
+++ b/.ort-data/curations-dir/voting-booth.yml
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
-- id: "Yarn::agora-gui-booth"
+- id: "Yarn::voting-booth"
   curations:
     comment: "This package needs to be downloaded from git"
     vcs:
       type: "git"
-      url: "https://github.com/agoravoting/agora-gui-common.git"
+      url: "https://github.com/sequentech/common-ui.git"
       revision: "4.0.1"

--- a/.ort-data/disclosure_document.ftl
+++ b/.ort-data/disclosure_document.ftl
@@ -1,7 +1,7 @@
 [#--
 SPDX-FileCopyrightText: 2020 HERE Europe B.V.
 SPDX-FileCopyrightText: 2020-2021 Bosch.IO GmbH
-SPDX-FileCopyrightText: 2021 Agora Voting SL
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc
 
 SPDX-License-Identifier: AGPL-3.0-only
 --]

--- a/.ort-data/license-classifications.yml
+++ b/.ort-data/license-classifications.yml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 # SPDX-FileCopyrightText: 2020-2021 Bosch.IO GmbH
 #
 # SPDX-License-Identifier: AGPL-3.0-only

--- a/.ort-data/rules.kts
+++ b/.ort-data/rules.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+ * SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
  * SPDX-FileCopyrightText: 2019 HERE Europe B.V.
  *
  * SPDX-License-Identifier: AGPL-3.0-only

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: frestq
-Upstream-Contact: Eduardo Robles Elvira <edulix@nvotes.com>
-Source: https://github.com/agoravoting/frestq
+Upstream-Contact: Eduardo Robles Elvira <edulix@sequentech.io>
+Source: https://github.com/sequentech/frestq
 
 # Sample paragraph, commented out:
 #

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-Eduardo Robles Elvira <edulix AT agoravoting DOT com>
-David Ruescas <david AT agoravoting DOT com>
+Eduardo Robles Elvira <edulix@sequentech.io>
+David Ruescas <david@sequentech.io>
 Daniel García Moreno <danigm AT wadobo DOT com>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->
@@ -26,7 +26,7 @@ time tou can proceed to install it manually as when you downloaded it:
 1. Download from the git repository if you haven't got a copy
 
 ```
-    $ git clone https://github.com/agoravoting/frestq && cd frestq
+    $ git clone https://github.com/sequentech/frestq && cd frestq
 ```
 
 2. Install package and its dependencies
@@ -232,21 +232,21 @@ the output in the shell running server A:
 
 # License
 
-Copyright (C) 2013-2020 Agora Voting SL and/or its subsidiary(-ies).
-Contact: legal@agoravoting.com
+Copyright (C) 2013-2020 Sequent Tech Inc and/or its subsidiary(-ies).
+Contact: legal@sequentech.io
 
-This file is part of the frestq module of the Agora Voting project.
+This file is part of the frestq module of the Sequent Tech project.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 Commercial License Usage
-Licensees holding valid commercial Agora Voting project licenses may use this
+Licensees holding valid commercial Sequent Tech project licenses may use this
 file in accordance with the commercial license agreement provided with the
 Software or, alternatively, in accordance with the terms contained in
-a written agreement between you and Agora Voting SL. For licensing terms and
-conditions and further information contact us at legal@agoravoting.com .
+a written agreement between you and Sequent Tech Inc. For licensing terms and
+conditions and further information contact us at legal@sequentech.io .
 
 GNU Affero General Public License Usage
 Alternatively, this file may be used under the terms of the GNU Affero General

--- a/docs/FRESTQP.md
+++ b/docs/FRESTQP.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/docs/RESTQP.md
+++ b/docs/RESTQP.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/examples/errorhandling/server.py
+++ b/examples/errorhandling/server.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/external/__init__.py
+++ b/examples/external/__init__.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/external/server_a.py
+++ b/examples/external/server_a.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/external/server_b.py
+++ b/examples/external/server_b.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/hellossl/README.md
+++ b/examples/hellossl/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->

--- a/examples/hellossl/cert.pem.license
+++ b/examples/hellossl/cert.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/examples/hellossl/certs/selfsigned/cert.pem.license
+++ b/examples/hellossl/certs/selfsigned/cert.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/examples/hellossl/certs/selfsigned/key-nopass.pem.license
+++ b/examples/hellossl/certs/selfsigned/key-nopass.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/examples/hellossl/certs/selfsigned/key_plus_cert.pem.license
+++ b/examples/hellossl/certs/selfsigned/key_plus_cert.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/examples/hellossl/certs/selfsigned2/cert.pem.license
+++ b/examples/hellossl/certs/selfsigned2/cert.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/examples/hellossl/certs/selfsigned2/key-nopass.pem.license
+++ b/examples/hellossl/certs/selfsigned2/key-nopass.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/examples/hellossl/key.pem.license
+++ b/examples/hellossl/key.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/examples/hellossl/nginx_hellossl.conf
+++ b/examples/hellossl/nginx_hellossl.conf
@@ -1,13 +1,13 @@
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 upstream frestq_a {
-    server unix:///home/edulix/proyectos/wadobo/agora/frestq/examples/hellossl/server_a.sock;
+    server unix:///home/edulix/proyectos/wadobo/sequent/frestq/examples/hellossl/server_a.sock;
 }
 
 upstream frestq_b {
-    server unix:///home/edulix/proyectos/wadobo/agora/frestq/examples/hellossl/server_b.sock;
+    server unix:///home/edulix/proyectos/wadobo/sequent/frestq/examples/hellossl/server_b.sock;
 }
 
 server {

--- a/examples/hellossl/server_a.py
+++ b/examples/hellossl/server_a.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/hellossl/server_b.py
+++ b/examples/hellossl/server_b.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/helloworld/server_a.py
+++ b/examples/helloworld/server_a.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/helloworld/server_b.py
+++ b/examples/helloworld/server_b.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/synchronized/__init__.py
+++ b/examples/synchronized/__init__.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/synchronized/common.py
+++ b/examples/synchronized/common.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/synchronized/server_a.py
+++ b/examples/synchronized/server_a.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/synchronized/server_b.py
+++ b/examples/synchronized/server_b.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/tasktree/__init__.py
+++ b/examples/tasktree/__init__.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/tasktree/common.py
+++ b/examples/tasktree/common.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/tasktree/server_a.py
+++ b/examples/tasktree/server_a.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/examples/tasktree/server_b.py
+++ b/examples/tasktree/server_b.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/frestq/__init__.py
+++ b/frestq/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only

--- a/frestq/action_handlers.py
+++ b/frestq/action_handlers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/frestq/api.py
+++ b/frestq/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/frestq/app.py
+++ b/frestq/app.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/frestq/decorators.py
+++ b/frestq/decorators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/frestq/frestq_app.py
+++ b/frestq/frestq_app.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/frestq/fscheduler.py
+++ b/frestq/fscheduler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/frestq/models.py
+++ b/frestq/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/frestq/protocol.py
+++ b/frestq/protocol.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/frestq/tasks.py
+++ b/frestq/tasks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/frestq/utils.py
+++ b/frestq/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2021  Agora Voting SL <contact@nvotes.com>
+# Copyright (C) 2014-2021  Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -7,8 +7,8 @@ from setuptools import setup
 setup(
     name='frestq',
     version='4.0.0',
-    author='Agora Voting SL',
-    author_email='contact@nvotes.com',
+    author='Sequent Tech Inc',
+    author_email='legal@sequentech.io',
     packages=['frestq'],
     scripts=[],
     url='http://pypi.python.org/pypi/frestq/',


### PR DESCRIPTION
Rebrands the whole repository from nVotes to Sequent Tech, changing all references in code, documentation, comments and file names. This rebranding includes the renaming of all the repositories too.