### PR TITLE
`master` branch should be using `master` version number and not `8.0.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name='frestq',
-    version='8.0.0',
+    version='4.0.0',
     author='Sequent Tech Inc',
     author_email='legal@sequentech.io',
     packages=['frestq'],


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/136

Revert "Release for version 8.0.0"

This reverts commit b6ffb105dcf22f1e464efd3fa9eb1a97ede44bc1.